### PR TITLE
adding align-wide styles

### DIFF
--- a/src/assets/scss/boldgrid/_editor-styles.scss
+++ b/src/assets/scss/boldgrid/_editor-styles.scss
@@ -6,3 +6,35 @@
 		max-width: (1170 * .75) + px !important;
 	}
 }
+
+// Gutenberg Additions.
+// Align Full
+.alignfull {
+	margin-left: calc( -100vw / 2 + 100% / 2 );
+	margin-right: calc( -100vw / 2 + 100% / 2 );
+	width: calc( 100vw - 7.5px );
+}
+
+// Align Wide.
+.alignwide {
+	width: calc( 100% + 30px);
+	margin-right: -15px;
+	margin-left: -15px;
+}
+.main-wrapper.container {
+	@media (min-width: 768px) {
+		.alignwide {
+			width: 750px;
+		}
+	}
+	@media (min-width: 992px) {
+		.alignwide {
+			width: 970px;
+		}
+	}
+	@media (min-width: 1200px) {
+		.alignwide {
+			width: 1170px;
+		}
+	}
+}

--- a/src/includes/class-boldgrid-framework-setup.php
+++ b/src/includes/class-boldgrid-framework-setup.php
@@ -68,6 +68,7 @@ class BoldGrid_Framework_Setup {
 		$this->woo_commerce_setup( );
 		$this->header_image_setup( );
 		$this->custom_logo_setup();
+		$this->align_wide();
 	}
 
 	/**
@@ -255,5 +256,14 @@ class BoldGrid_Framework_Setup {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Add support for alignwide and alignfull classes.
+	 *
+	 * @since 2.1.1
+	 */
+	public function align_wide() {
+		add_theme_support( 'align-wide' );
 	}
 }


### PR DESCRIPTION
This adds align-wide classes for Gutenberg compatibility.  

The `.alignfull` is full width for blocks.

The `.alignwide` is -15px left/right of container/full-width.

When the `.main-wrapper` is set to be contained, the `.alignwide` acts as the same width as the container, minus the 15px of padding on left/right.  Similar to what the .bg-box stuff does from the post and page builder plugin.