### PR TITLE
add base gutenberg button styles

### DIFF
--- a/src/assets/scss/boldgrid/_editor-styles.scss
+++ b/src/assets/scss/boldgrid/_editor-styles.scss
@@ -6,3 +6,14 @@
 		max-width: (1170 * .75) + px !important;
 	}
 }
+
+// Gutenberg Button Styles
+// Buttons
+.entry-content a.wp-block-button__link {
+	&, &:hover, &:focus {
+		text-decoration: none;
+	}
+	&:hover, &:focus {
+		opacity: .9;
+	}
+}


### PR DESCRIPTION
This adds base styles for Gutenberg buttons.

Testing markup:

```
<div class="wp-block-button"><a class="wp-block-button__link">Rounded</a></div>
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link">Outline<br></a></div>
<div class="wp-block-button is-style-squared"><a class="wp-block-button__link">Square<br></a></div>
```