### PR TITLE
Update support to lts node

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "type": "git",
     "url": "https://github.com/BoldGrid/boldgrid-theme-framework.git"
   },
+  "resolutions": {
+    "natives": "1.1.6"
+  },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.47",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "BoldGrid Theme Framework",
   "main": "index.js",
   "engines": {
-    "node": ">=10.12.0 <=10.13.0"
+    "node": ">=10.12.0"
   },
   "babel": {
     "plugins": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9336,7 +9336,7 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@^1.1.0:
+natives@1.1.6, natives@^1.1.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
   integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9337,9 +9337,9 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 natives@^1.1.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.4.tgz#2f0f224fc9a7dd53407c7667c84cf8dbe773de58"
-  integrity sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
The two main issues I kept seeing from with gulp and the latest node version is upath > 1.1.0 and natives > 1.1.6. 

Updating the following dependency allows you to run the build on the latest node version without updating gulp to version 4.

