### PR TITLE
Fix/fonts in editor

### DIFF
--- a/src/includes/class-boldgrid-framework-editor.php
+++ b/src/includes/class-boldgrid-framework-editor.php
@@ -70,7 +70,10 @@ class Boldgrid_Framework_Editor {
 
 		$mce_inline_styles = '';
 		$mce_inline_styles = apply_filters( 'boldgrid_mce_inline_styles', $mce_inline_styles );
-		$mce_inline_styles = apply_filters( 'kirki/global/dynamic_css', $mce_inline_styles );
+
+		$kirki_css = Kirki_Modules_CSS::get_instance();
+		$mce_inline_styles .= apply_filters( 'kirki_global_dynamic_css', $kirki_css::loop_controls( 'global' ) );
+		$mce_inline_styles .= apply_filters( 'kirki_bgtfw_dynamic_css', $kirki_css::loop_controls( 'bgtfw' ) );
 
 		wp_localize_script( 'mce-view', 'BOLDGRID_THEME_FRAMEWORK',
 			array(

--- a/src/includes/configs/customizer/controls.config.php
+++ b/src/includes/configs/customizer/controls.config.php
@@ -1319,6 +1319,7 @@ return array(
 		'output'      => array(
 			array(
 				'element' => '.widget, .site-content, .attribution-theme-mods-wrapper, .gutenberg .edit-post-visual-editor, .mce-content-body',
+				'context' => [ 'front', 'editor' ],
 			),
 		),
 	),

--- a/src/includes/customizer/class-boldgrid-framework-customizer-typography.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer-typography.php
@@ -284,6 +284,7 @@ class Boldgrid_Framework_Customizer_Typography {
 				'element' => $elements,
 				'property' => $prop,
 				'choice' => $prop,
+				'context' => [ 'front', 'editor' ],
 			];
 		}
 


### PR DESCRIPTION
Fixes an issue that prevents the fonts from rendering correctly in both gutenberg and the post and page builder.

The first change allows us to bypass a conditional within the Kirki output class which will skip output unless explicitly requested in the context. The second change pulls in bgtfw dynamic styles in the tinymce context.

Testing: 

- Load the post and page builder with a custom font family for the body. Should be wysiwyg
- Load gutenberg with a custom font family for the body. Should be wysiwyg