### PR TITLE
corrected bootrstrap display issue on safari

### DIFF
--- a/src/assets/scss/boldgrid/_elements.scss
+++ b/src/assets/scss/boldgrid/_elements.scss
@@ -17,6 +17,11 @@ body.custom-background {
 	backface-visibility: hidden;
 }
 
+.row:before,
+.row:after {
+	display: inline-block;
+	}
+
 .site-content {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
This resolves #25 by setting display:inline-block on .row::before and .row::after