### PR TITLE
removed boldgrid_framework_reset action.

### DIFF
--- a/src/includes/class-boldgrid-framework.php
+++ b/src/includes/class-boldgrid-framework.php
@@ -512,7 +512,6 @@ class BoldGrid_Framework {
 
 		// Actions.
 		$this->loader->add_action( 'boldgrid_activate_framework', $activate, 'do_activate' );
-		$this->loader->add_action( 'boldgrid_framework_reset', $activate, 'reset' );
 
 		if ( true === $this->configs['tgm']['enabled'] ) {
 			$this->loader->add_action( 'tgmpa_register', $activate, 'register_required_plugins' );


### PR DESCRIPTION
This resolves #173 by removing the 'boldgrid_framework_reset' action altogether, since the function it calls, Boldgrid_Framework_Activate->reset() no longer exists