### PR TITLE
fixed attribution alignment on phone device

### DIFF
--- a/src/assets/js/front-end.js
+++ b/src/assets/js/front-end.js
@@ -39,6 +39,17 @@ var BoldGrid = BoldGrid || {};
 				this.skipLink();
 				this.forms();
 				this.cssVarsPonyfill();
+				this.mobileFooter();
+			},
+
+			// remove attribution seperators on mobile devices.
+			mobileFooter: function() {
+				var width = $( window ).width();
+				if ( 782 >= width ) {
+					$( '.attribution-theme-mods .link' ).addClass( 'no-separator' );
+					$( '.attribution-theme-mods' ).removeClass( 'flex-row' );
+					$( '.attribution-theme-mods' ).addClass( 'flex-column' );
+				}
 			},
 
 			// Observe classList changes on body element.


### PR DESCRIPTION
This resolves #177 by using jQuery to add the class no-seperator to the attribution links, if the screen width is 782px or less. Additionally, it changes the .attribution-theme-mods from flex-row to flex-column to give a better looking alignment.

![image](https://user-images.githubusercontent.com/49331357/77186504-5cf81180-6aa9-11ea-9be4-703bcadf28b1.png)
