### PR TITLE
Adjusted WooCommerce store notice positioning.

### DIFF
--- a/src/assets/js/front-end.js
+++ b/src/assets/js/front-end.js
@@ -39,8 +39,6 @@ var BoldGrid = BoldGrid || {};
 				this.skipLink();
 				this.forms();
 				this.cssVarsPonyfill();
-				this.demoStore();
-				$( window ).on( 'resize', this.demoStore );
 			},
 
 			// Observe classList changes on body element.
@@ -97,14 +95,6 @@ var BoldGrid = BoldGrid || {};
 						func.apply( context, args );
 					}
 				};
-			},
-
-			// Set correct height of .demo_store notice.
-			demoStore: function() {
-				if ( 0 !== $( '.demo_store:visible' ).length ) {
-					$( '.demo_store' ).css( 'top', window.innerHeight - $( '.demo_store' ).outerHeight() );
-					$( '.goup-container' ).css( 'bottom', $( '.demo_store' ).outerHeight() + 30 );
-				}
 			},
 
 			// JavaScript to be fired on all pages, after page specific JS is fired.

--- a/src/assets/js/front-end.js
+++ b/src/assets/js/front-end.js
@@ -39,6 +39,8 @@ var BoldGrid = BoldGrid || {};
 				this.skipLink();
 				this.forms();
 				this.cssVarsPonyfill();
+				this.demoStore();
+				$( window ).on( 'resize', this.demoStore );
 			},
 
 			// Observe classList changes on body element.
@@ -95,6 +97,14 @@ var BoldGrid = BoldGrid || {};
 						func.apply( context, args );
 					}
 				};
+			},
+
+			// Set correct height of .demo_store notice.
+			demoStore: function() {
+				if ( 0 !== $( '.demo_store:visible' ).length ) {
+					$( '.demo_store' ).css( 'top', window.innerHeight - $( '.demo_store' ).outerHeight() );
+					$( '.goup-container' ).css( 'bottom', $( '.demo_store' ).outerHeight() + 30 );
+				}
 			},
 
 			// JavaScript to be fired on all pages, after page specific JS is fired.
@@ -226,6 +236,7 @@ var BoldGrid = BoldGrid || {};
 		// Header Top.
 		'custom_header': {
 			init: function() {
+
 				// Check for custom header image.
 				this.checkImg();
 

--- a/src/assets/scss/boldgrid/woocommerce/_demo-notice.scss
+++ b/src/assets/scss/boldgrid/woocommerce/_demo-notice.scss
@@ -5,6 +5,9 @@
 	justify-content: center;
 	margin: 0;
 	position: fixed;
+	bottom: 0px;
+	top: inherit;
+
 	@at-root #{selector-append('.header-fixed.header-top', &)} {
 		height: 57px;
 		min-height: 57px;
@@ -14,6 +17,8 @@
 		padding: 0;
 		position: fixed;
 		height: fit-content;
+		bottom: 0px;
+		top: inherit;
 	}
 	@at-root #{selector-append('.header-left,.header-right', &)} {
 		height: 57px;

--- a/src/assets/scss/boldgrid/woocommerce/_demo-notice.scss
+++ b/src/assets/scss/boldgrid/woocommerce/_demo-notice.scss
@@ -4,7 +4,7 @@
 	align-items: center;
 	justify-content: center;
 	margin: 0;
-	position: relative;
+	position: fixed;
 	@at-root #{selector-append('.header-fixed.header-top', &)} {
 		height: 57px;
 		min-height: 57px;
@@ -13,12 +13,7 @@
 		min-height: 57px;
 		padding: 0;
 		position: fixed;
-		@at-root #{selector-append('.admin-bar', &)} {
-			@media screen and (max-width: 782px) {
-				position: absolute;
-				top: 46px;
-			}
-		}
+		height: fit-content;
 	}
 	@at-root #{selector-append('.header-left,.header-right', &)} {
 		height: 57px;
@@ -29,7 +24,9 @@
 		margin-left: -2.8rem;
 		margin-right: -2.8rem;
 	}
+
 	a {
 		padding-left: 1em;
+		padding-right: 1em;
 	}
 }


### PR DESCRIPTION
When enabling a WooCommerce store notice, by default it is absolute positioned at the top of the page. However, bgtfw has it adjusted to be absolute positioned at the bottom of the page. This is undesireable as the notice will not be seen unless someone scrolls to the bottom of the page.

This PR aims to resolve #39 , however, placing the notice at the very top of the page will ave other undesireable effects, such as covering the site logo, the menu, etc. Even if the notice was placed under the masthead, if the user has submenus, it wouldn't really look right. Placing it fixed bottom of the window is better in my opinion. 

There may be a feature request in the near future to give users the ability to choose the location.