### PR TITLE
fixed errors when woocommerce not installed

### DIFF
--- a/src/assets/js/customizer/design/woocommerce/section-expand.js
+++ b/src/assets/js/customizer/design/woocommerce/section-expand.js
@@ -1,6 +1,7 @@
 /* esversion: 6 */
 import ExpandSection from '../../expand/section';
 
+// eslint-disable-next-line no-unused-vars
 const api = wp.customize;
 
 /**
@@ -34,6 +35,7 @@ export class WoocommerceSectionExpand extends ExpandSection {
 	 * @return {String} this.url The URL for the previewer.
 	 */
 	setUrl() {
+		// eslint-disable-next-line no-undef
 		this.url = BOLDGRID.CUSTOMIZER.data.design.woocommerce.shopUrl;
 		return this.url;
 	}

--- a/src/includes/class-boldgrid-framework-api.php
+++ b/src/includes/class-boldgrid-framework-api.php
@@ -210,7 +210,7 @@ class BoldGrid {
 		global $boldgrid_theme_framework;
 		$theme_mod_type = $boldgrid_theme_framework->woo->is_woocommerce_page() ? 'bgtfw_woocommerce_container' : 'bgtfw_blog_page_container';
 
-		if ( ( isset( $wp_query ) && ( bool ) $wp_query->is_posts_page ) || is_home() || is_archive() || is_shop() ) {
+		if ( ( isset( $wp_query ) && ( bool ) $wp_query->is_posts_page ) || is_home() || is_archive() || ( function_exists( 'is_shop' ) && is_shop() ) ) {
 			$theme_mod = get_theme_mod( $theme_mod_type );
 			$classes[] = empty( $theme_mod ) ? 'full-width' : 'container';
 		}

--- a/src/includes/customizer/class-boldgrid-framework-customizer.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer.php
@@ -508,7 +508,7 @@ class BoldGrid_Framework_Customizer {
 				],
 				'woocommerce' => [
 					'shopUrl' => esc_js(
-						wc_get_page_permalink( 'shop' )
+						function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'shop' ) : get_option( 'siteurl' )
 					),
 				],
 			],


### PR DESCRIPTION
This resolves a problem with 2.1.18-rc1 which causes errors if woocommerce is NOT installed / activated