### PR TITLE
add page title to cart and checkout pages

### DIFF
--- a/src/includes/class-boldgrid-framework-woocommerce.php
+++ b/src/includes/class-boldgrid-framework-woocommerce.php
@@ -307,4 +307,22 @@ class BoldGrid_Framework_Woocommerce {
 		$classes[] = 'input-number';
 		return $classes;
 	}
+
+	/**
+	 * Adds page title to a shop Page.
+	 *
+	 * @since 2.2.16
+	 */
+	public function add_page_title() {
+		if ( 'hide' !== get_theme_mod( 'bgtfw_pages_title_display' ) ) {
+			$slug   = get_post_field( 'post_name', get_post() );
+			$markup = '
+				<header class="woocommerce-' . esc_attr( $slug ) . '-header">
+					<h1 class="woocommerce-' . esc_attr( $slug ) . '-header__title page-title">
+					' . esc_attr( get_the_title() ) . '
+					</h1>
+				</header>';
+			echo $markup; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+	}
 }

--- a/src/includes/class-boldgrid-framework.php
+++ b/src/includes/class-boldgrid-framework.php
@@ -985,6 +985,8 @@ class BoldGrid_Framework {
 		$this->loader->add_filter( 'woocommerce_quantity_input_classes', $woo, 'quantity_input_classes' );
 		$this->loader->add_action( 'woocommerce_before_quantity_input_field', $woo, 'quantity_input_before' );
 		$this->loader->add_action( 'woocommerce_after_quantity_input_field', $woo, 'quantity_input_after' );
+		$this->loader->add_action( 'woocommerce_before_cart', $this->woo, 'add_page_title' );
+		$this->loader->add_action( 'woocommerce_before_checkout_form', $this->woo, 'add_page_title' );
 
 		remove_all_actions( 'woocommerce_sidebar' );
 		add_filter( 'loop_shop_per_page', function( $cols ) {


### PR DESCRIPTION
This PR goes along with [#77](https://github.com/BoldGrid/prime/pull/77) . By removing the duplicate headers, this also removes the page titles from the cart and checkout pages. This adds them back in a way that is consistent with the Product and Shop pages. This is to resolve [#66](https://github.com/BoldGrid/prime/issues/66)