### PR TITLE
moved containter subsection to 'if' conditional

### DIFF
--- a/src/includes/configs/customizer/sections.config.php
+++ b/src/includes/configs/customizer/sections.config.php
@@ -41,14 +41,6 @@ $sections_array = array(
 		'capability' => 'edit_theme_options',
 		'icon' => 'icon-layout-container',
 	),
-	'bgtfw_layout_woocommerce_container' => array(
-		'title' => __( 'Container', 'bgtfw' ),
-		'panel' => 'bgtfw_design_panel',
-		'section' => 'bgtfw_layout_woocommerce',
-		'description' => esc_html__( 'This section controls the container for your WooCommerce pages.', 'bgtfw' ),
-		'capability' => 'edit_theme_options',
-		'icon' => 'icon-layout-container',
-	),
 	'bgtfw_layout_page_sidebar' => array(
 		'title' => __( 'Sidebar', 'bgtfw' ),
 		'panel' => 'bgtfw_design_panel',
@@ -420,6 +412,14 @@ if ( $is_woocommerce ) {
 		'capability'  => 'edit_theme_options',
 		'priority'    => 1,
 		'icon'        => 'dashicons-admin-page',
+	);
+	$sections_array['bgtfw_layout_woocommerce_container'] = array(
+		'title'       => __( 'Container', 'bgtfw' ),
+		'panel'       => 'bgtfw_design_panel',
+		'section'     => 'bgtfw_layout_woocommerce',
+		'description' => esc_html__( 'This section controls the container for your WooCommerce pages.', 'bgtfw' ),
+		'capability'  => 'edit_theme_options',
+		'icon'        => 'icon-layout-container',
 	);
 }
 


### PR DESCRIPTION
as a result of a misunderstanding on how the controls / sections config worked, I assumed that if the section was not added, then the subsections of that section wouldn't ether. However, it appears that if a section isn't added, then the subsections just get moved up into whatever panel they're in.

Therefore, the 'bgtfw_layout_woocommerce_container' subsection was moved to the end of the file into a conditional along with the 'bgtfw_layout_woocommerce' section .

This resolves #216 