### PR TITLE
set hide boldgrid attribution to not show with free

### DIFF
--- a/src/boldgrid-theme-framework.php
+++ b/src/boldgrid-theme-framework.php
@@ -3,7 +3,7 @@
  * Plugin Name: BoldGrid Theme Framework
  * Plugin URI: https://www.boldgrid.com/docs/configuration-file
  * Description: BoldGrid Theme Framework is a library that allows you to easily make BoldGrid themes. Please see our reference guide for more information: https://www.boldgrid.com/docs/configuration-file
- * Version: 1.7.3
+ * Version: 1.7.5-rc.1
  * Author: BoldGrid.com <wpb@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Text Domain: bgtfw

--- a/src/includes/customizer/class-boldgrid-framework-customizer-footer.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer-footer.php
@@ -192,18 +192,6 @@ class Boldgrid_Framework_Customizer_Footer {
 			'',
 			array(
 				'type'        => 'checkbox',
-				'settings'     => 'hide_boldgrid_attribution',
-				'transport'   => 'refresh',
-				'label'       => __( 'Hide BoldGrid Attribution', 'bgtfw' ),
-				'section'     => 'boldgrid_footer_panel',
-				'default'     => false,
-				'priority'    => 30,
-			)
-		);
-		Kirki::add_field(
-			'',
-			array(
-				'type'        => 'checkbox',
 				'settings'     => 'hide_wordpress_attribution',
 				'transport'   => 'refresh',
 				'label'       => __( 'Hide WordPress Attribution', 'bgtfw' ),

--- a/src/includes/customizer/class-boldgrid-framework-customizer.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer.php
@@ -136,18 +136,6 @@ class BoldGrid_Framework_Customizer {
 			'bgtfw',
 			array(
 				'type'        => 'checkbox',
-				'settings'     => 'hide_boldgrid_attribution',
-				'transport'   => 'refresh',
-				'label'       => __( 'Hide BoldGrid Attribution', 'bgtfw' ),
-				'section'     => 'boldgrid_footer_panel',
-				'default'     => false,
-				'priority'    => 30,
-			)
-		);
-		Kirki::add_field(
-			'bgtfw',
-			array(
-				'type'        => 'checkbox',
 				'settings'     => 'hide_wordpress_attribution',
 				'transport'   => 'refresh',
 				'label'       => __( 'Hide WordPress Attribution', 'bgtfw' ),
@@ -156,6 +144,21 @@ class BoldGrid_Framework_Customizer {
 				'priority'    => 40,
 			)
 		);
+		// If there is host attribution markup, add a control to hide it.
+		if ( get_theme_mod( 'host_attribution' ) ) {
+			Kirki::add_field(
+				'bgtfw',
+				array(
+					'type'      => 'checkbox',
+					'settings'  => 'hide_host_attribution',
+					'transport' => 'refresh',
+					'label'     => __( 'Hide Host Attribution', 'bgtfw' ),
+					'section'   => 'boldgrid_footer_panel',
+					'default'   => false,
+					'priority'  => 40,
+				)
+			);
+		}
 		Kirki::add_field(
 			'bgtfw',
 			array(


### PR DESCRIPTION
This is to resolve the boldgrid attribution issues in v1 themes