### PR TITLE
disable preloader for vs 5.5+

### DIFF
--- a/src/assets/scss/boldgrid/_preload.scss
+++ b/src/assets/scss/boldgrid/_preload.scss
@@ -16,8 +16,8 @@
 			opacity: 0;
 		}
 	}
-	&.bgtfw-loaded.wf-active,
-		&.bgtfw-loaded.wf-inactive {
+	&.bgtfw-loaded,
+		&.bgtfw-loaded {
 			#boldgrid-sticky-wrap,
 			#colophon {
 				-webkit-animation: fadein 1s linear forwards;
@@ -36,8 +36,8 @@
 			opacity: 0;
 		}
 	}
-	&.bgtfw-loaded.wf-active,
-		&.bgtfw-loaded.wf-inactive {
+	&.bgtfw-loaded,
+		&.bgtfw-loaded {
 			#boldgrid-sticky-wrap,
 			#colophon {
 				opacity: 1;

--- a/src/includes/class-boldgrid-framework-scripts.php
+++ b/src/includes/class-boldgrid-framework-scripts.php
@@ -244,6 +244,8 @@ class BoldGrid_Framework_Scripts {
 	 * @since 1.3.6
 	 */
 	public function modernizr( $output ) {
+		global $wp_version;
+
 		// Do not run this on login screen -- modernizer script is not enqueued.
 		$script_name = isset( $_SERVER['SCRIPT_NAME'] ) ? $_SERVER['SCRIPT_NAME'] : '';
 		if ( false !== stripos( wp_login_url(), $script_name ) ) {
@@ -252,7 +254,11 @@ class BoldGrid_Framework_Scripts {
 
 		$admin_bar = is_admin_bar_showing() ? ' admin-bar' : '';
 
-		$preload = ( ! get_theme_mod( 'bgtfw_preloader_type', '' ) || 'off' === get_theme_mod( 'bgtfw_preloader_type', '' ) ) ? '' : get_theme_mod( 'bgtfw_preloader_type' ) . ' ';
+		if ( version_compare( $wp_version, '5.4.99', 'gt' ) ) {
+			$preload = '';
+		} else {
+			$preload = ( ! get_theme_mod( 'bgtfw_preloader_type', '' ) || 'off' === get_theme_mod( 'bgtfw_preloader_type', '' ) ) ? '' : get_theme_mod( 'bgtfw_preloader_type' ) . ' ';
+		}
 
 		return "$output class='{$preload}no-bgtfw no-js{$admin_bar}'";
 	}

--- a/src/includes/class-boldgrid-framework.php
+++ b/src/includes/class-boldgrid-framework.php
@@ -239,6 +239,7 @@ class BoldGrid_Framework {
 	 * @access   public
 	 */
 	public function assign_configurations() {
+		global $wp_version;
 		$this->configs = include plugin_dir_path( dirname( __FILE__ ) ) . 'includes/configs/configs.php';
 		// Based on the configs already assigned, set config values to help assign later values.
 		$this->assign_dynamic_configs();
@@ -247,6 +248,10 @@ class BoldGrid_Framework {
 		$this->assign_configs( 'customizer-options' );
 		$this->assign_configs( 'customizer' );
 		$this->assign_configs( 'components' );
+
+		if ( version_compare( $wp_version, '5.4.99', 'gt' ) && isset( $this->configs['customizer']['controls']['bgtfw_preloader_type'] ) ) {
+			unset( $this->configs['customizer']['controls']['bgtfw_preloader_type'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
webfonts are loaded differently, effectively breaking the 'preloader' which should have just not been used at all anyways. This disables the controls and the preloader for 5.5 .