### PR TITLE
Prevent Null Return Value for MCE Plugins

### DIFF
--- a/src/includes/class-boldgrid-framework-editor.php
+++ b/src/includes/class-boldgrid-framework-editor.php
@@ -160,13 +160,13 @@ HTML;
 		);
 
 		if ( ! empty( $pagenow ) && ! in_array( $pagenow, $valid_pages ) ) {
-			return;
+			return $plugin_array;
 		}
 
 		// Currently only pages and posts are supported. @since 1.3.1
 		if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
 			if ( ! in_array( $this->get_post_type(), $valid_post_types ) ) {
-				return;
+				return $plugin_array;
 			}
 		}
 


### PR DESCRIPTION
This issue has already been resolved in the V2 Framework, but if a user of a V1 Theme attempts to load a custom post type that uses the TinyMCE Editor, a fatal error is thrown because of the null return value. @jamesros161 can you review and release a patch for V1? CC @bwmarkle