### PR TITLE
Featured images for posts on blog page should link to post.

### DIFF
--- a/src/assets/scss/boldgrid/blog/design/_base.scss
+++ b/src/assets/scss/boldgrid/blog/design/_base.scss
@@ -106,7 +106,15 @@ main {
 		}
 		.featured-imgage-header {
 			margin: 0 auto;
-			width: 100%
+			width: 100%;
+			position: relative;
+			a.featured-image-link {
+				position: absolute;
+				top: 0;
+				left: 0;
+				bottom: 0;
+				right: 0;
+			}
 		}
 		.entry-title,
 		.entry-meta {


### PR DESCRIPTION
This addresses #399 

# Description #
Featured images for posts on blog page should link to post. The solution decided for this feature is, rather than have a toggle for whether the featured images should be links or not, this behavior will be standard. This is understood / expected behavior which was not previously included.

# Testing Procedure #

1. Install the test version of Crio attached to this PR. ( Alternatively, if you wish, you can update an existing installation using the included zip file )