### PR TITLE
resolves #721

### DIFF
--- a/src/assets/scss/editor.scss
+++ b/src/assets/scss/editor.scss
@@ -1,6 +1,11 @@
 /** Set Gutenberg metabox styles **/
 .js.block-editor-page {
 
+	h1, h2, h3, h4, h5, h6 {
+		font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+		color: #3c434a;
+	}
+
 	#bgtfw-attributes-meta-box.postbox {
 
 		.handlediv {


### PR DESCRIPTION
Resolves #721 

## Testing Instructions ##
1. Install Crio without PPB or Inspirations.
[crio-2.17.1-rc.zip](https://github.com/BoldGrid/boldgrid-theme-framework/files/9707709/crio-2.17.1-rc.zip)

2. Change the heading font to something easily distinguishable from the default heading font.
3. Edit a page or post, and add an image block
4. open the 'Add Media' modal from within the image block.
5. Ensure that the headings in the modal do not show the Customizer Heading Fonts, but instead shows the standard WP Core heading font.