### PR TITLE
resolve missing tags in saveHTML()

### DIFF
--- a/src/includes/customizer/class-boldgrid-framework-customizer-colors.php
+++ b/src/includes/customizer/class-boldgrid-framework-customizer-colors.php
@@ -363,11 +363,13 @@ class Boldgrid_Framework_Customizer_Colors {
 			return;
 		}
 
+		libxml_use_internal_errors( true );
+
 		// Create an instance of DOMDocument
 		$dom = new \DOMDocument();
 
 		// Handle UTF-8, otherwise problems will occur with UTF-8 characters.
-		$dom->loadHTML( mb_convert_encoding( $post_content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		$dom->loadHTML( mb_convert_encoding( '<html>' . $post_content . '</html>', 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 
 		$elements = $dom->getElementsByTagName( '*' );
 
@@ -417,6 +419,8 @@ class Boldgrid_Framework_Customizer_Colors {
 		}
 
 		$new_content = $dom->saveHTML();
+		$new_content = str_replace( '<html>', '', $new_content );
+		$new_content = str_replace( '</html>', '', $new_content );
 
 		// Update the post content.
 		wp_update_post(


### PR DESCRIPTION
Resolves #750 

### Testing Instructions ###
1. Install Inspirations
2. Use DH Dentistry design
3. Upload the Crio test zip to replace the version of Crio installed by inspirations.
[crio.zip](https://github.com/BoldGrid/boldgrid-theme-framework/files/9890126/crio.zip)

5. Change the color palette in the Customizer
6. View the cosmetic-dentistry page to ensure that the section background in the 3rd block hits the side and a closing was not stripped from the first section