### PR TITLE
change color of template subtitles

### DIFF
--- a/src/assets/scss/attributes.scss
+++ b/src/assets/scss/attributes.scss
@@ -32,6 +32,10 @@
   display: inline;
   margin: 0;
   text-transform: capitalize;
+  color: #3c434a;
+}
+.postbox .template-subtitle {
+  color: #3c434a;
 }
 
 #bgtfw-attributes-meta-box div.inside {


### PR DESCRIPTION
Resolves #755 

### Testing Instructions ###
1. Install Test zip.
[crio.zip](https://github.com/BoldGrid/boldgrid-theme-framework/files/9890404/crio.zip)

2. Install Post and Page Builder.
3. Edit a page or post
4. Ensure that the sub-titles in the metabox are black ( instead of gray as shown in the attached image ).
![195172584-8adf5e72-b3a5-49fa-b3b3-e5a4151e3ff2](https://user-images.githubusercontent.com/49331357/198684971-e6469ac4-e92a-47d5-a9ce-914d271bb381.png)
