### PR TITLE
Issue 741

### DIFF
--- a/src/assets/js/customizer/typography/link-preview.js
+++ b/src/assets/js/customizer/typography/link-preview.js
@@ -122,6 +122,22 @@ export class LinkPreview {
 				footerLinkColorHover  = parseInt( footerLinkColorHover, 10 ) / 100,
 				footerShiftedColorVal = colorLib.Color( footerLinkColor ).lightenByAmount( footerLinkColorHover ).toCSS();
 
+				let colorPaletteOption = JSON.parse( api( 'boldgrid_color_palette' )() );
+
+				let paletteColors  = colorPaletteOption.state.palettes['palette-primary'].colors;
+				let paletteNeutral = colorPaletteOption.state.palettes['palette-primary']['neutral-color'];
+
+				[ 1, 2, 3, 4, 5, 'neutral' ].map( sidebarColorClass => {
+					var sidebarColor      = 'neutral' === sidebarColorClass ? paletteNeutral : paletteColors[ sidebarColorClass - 1 ],
+						sidebarColorHover = api( 'bgtfw_body_link_color_hover' )() || 0,
+						sidebarAriColor;
+
+						sidebarColorHover = parseInt( sidebarColorHover, 10 ) / 100;
+						sidebarAriColor   = colorLib.Color( sidebarColor ).lightenByAmount( sidebarColorHover ).toCSS();
+
+						css += `.sidebar.color-${sidebarColorClass}-link-color a:not( .btn ):hover, .sidebar.color-${sidebarColorClass}-link-color a:not( .btn ):focus { color: ${sidebarAriColor} !important; }`;
+				} );
+
 				css += `
 				#colophon .bgtfw-footer.footer-content > a:not( .btn ),
 				#colophon .bgtfw-footer.footer-content *:not( .menu-item ) > a:not( .btn ) {

--- a/src/assets/scss/custom-color/color-classes.scss
+++ b/src/assets/scss/custom-color/color-classes.scss
@@ -105,18 +105,12 @@ $names: background background-color;
 				a:not( .btn ) {
 					color: #{nth($colors, $each)};
 				}
-				a:not( .btn ):hover, a:not( .btn ):focus, a:not( .btn ):active, a:not( .btn ).highlighted {
-					color: hover( nth($colors, $color), nth($colors, $each) );
-				}
 			}
 		}
 		@if variable-exists( palette-primary-neutral-color ) {
 			&.color-neutral-link-color {
 				a:not( .btn ) {
 					color: $palette-primary-neutral-color;
-				}
-				a:not( .btn ):hover, a:not( .btn ):focus, a:not( .btn ):active, a:not( .btn ).highlighted {
-					color: hover( nth($colors, $color), $palette-primary-neutral-color );
 				}
 			}
 			&.color-neutral-sub-link-color.sm {
@@ -158,9 +152,6 @@ $names: background background-color;
 					&.color-#{$each}-link-color {
 						a:not( .btn ) {
 							color: #{nth($colors, $each)};
-						}
-						a:not( .btn ):hover, a:not( .btn ):focus, a:not( .btn ):active, a:not( .btn ).highlighted {
-							color: hover( nth($colors, $color), nth($colors, $each) );
 						}
 					}
 				}
@@ -249,8 +240,10 @@ $names: background background-color;
 					a {
 						color: #{nth($colors, $each)};
 					}
-					a:hover, a:focus, a:active, a.highlighted {
-						color: hover( $palette-primary-neutral-color, nth($colors, $each) );
+					&:not( .sidebar ) {
+						a:hover, a:focus, a:active, a.highlighted {
+							color: hover( $palette-primary-neutral-color, nth($colors, $each) );
+						}
 					}
 				}
 				&.color-#{$each}-sub-link-color.sm {

--- a/src/includes/class-boldgrid-framework-links.php
+++ b/src/includes/class-boldgrid-framework-links.php
@@ -175,7 +175,8 @@ class Boldgrid_Framework_Links {
 						$sidebar_lightness   = min( $sidebar_ari_color->lightness + $sidebar_color_hover, 100 );
 						$sidebar_lightness   = max( $sidebar_lightness, 0 );
 						$sidebar_color_hover = $sidebar_ari_color->getNew( 'lightness', $sidebar_lightness )->toCSS( 'hsla' );
-						$css .= ".sidebar.color-${sidebar_color_class}-link-color a:not( .btn ):hover, .sidebar.color-${sidebar_color_class}-link-color a:not( .btn ):focus { color: ${sidebar_color_hover}; }";
+
+						$css .= ".sidebar.color-${sidebar_color_class}-link-color a:not( .btn ):hover, .sidebar.color-${sidebar_color_class}-link-color a:not( .btn ):focus { color: ${sidebar_color_hover} !important; }";
 					}
 
 					$css .= "#colophon .bgtfw-footer.footer-content *:not( .menu-item ) > a:not( .btn ) { text-decoration: ${decoration};}";

--- a/src/includes/class-boldgrid-framework-links.php
+++ b/src/includes/class-boldgrid-framework-links.php
@@ -168,6 +168,16 @@ class Boldgrid_Framework_Links {
 					$footer_lightness   = max( $footer_lightness, 0 );
 					$footer_color_hover = $footer_ari_color->getNew( 'lightness', $footer_lightness )->toCSS( 'hsla' );
 
+					foreach( array( '1', '2', '3', '4', '5', 'neutral' ) as $sidebar_color_class ) {
+						$sidebar_color_value = BoldGrid::color_from_class( $sidebar_color_class );
+						$sidebar_color_hover = get_theme_mod( "bgtfw_body_link_color_hover" ) ?: 0;
+						$sidebar_ari_color   = ariColor::newColor( $sidebar_color_value );
+						$sidebar_lightness   = min( $sidebar_ari_color->lightness + $sidebar_color_hover, 100 );
+						$sidebar_lightness   = max( $sidebar_lightness, 0 );
+						$sidebar_color_hover = $sidebar_ari_color->getNew( 'lightness', $sidebar_lightness )->toCSS( 'hsla' );
+						$css .= ".sidebar.color-${sidebar_color_class}-link-color a:not( .btn ):hover, .sidebar.color-${sidebar_color_class}-link-color a:not( .btn ):focus { color: ${sidebar_color_hover}; }";
+					}
+
 					$css .= "#colophon .bgtfw-footer.footer-content *:not( .menu-item ) > a:not( .btn ) { text-decoration: ${decoration};}";
 					$css .= "#colophon .bgtfw-footer.footer-content *:not( .menu-item ) > a:not( .btn ):hover, .bgtfw-footer.footer-content *:not( .menu-item ) > a:not( .btn ):focus {color: ${footer_color_hover};text-decoration: ${decoration_hover};}";
 				}

--- a/src/includes/class-boldgrid-framework-links.php
+++ b/src/includes/class-boldgrid-framework-links.php
@@ -168,9 +168,9 @@ class Boldgrid_Framework_Links {
 					$footer_lightness   = max( $footer_lightness, 0 );
 					$footer_color_hover = $footer_ari_color->getNew( 'lightness', $footer_lightness )->toCSS( 'hsla' );
 
-					foreach( array( '1', '2', '3', '4', '5', 'neutral' ) as $sidebar_color_class ) {
+					foreach ( array( '1', '2', '3', '4', '5', 'neutral' ) as $sidebar_color_class ) {
 						$sidebar_color_value = BoldGrid::color_from_class( $sidebar_color_class );
-						$sidebar_color_hover = get_theme_mod( "bgtfw_body_link_color_hover" ) ?: 0;
+						$sidebar_color_hover = get_theme_mod( 'bgtfw_body_link_color_hover' ) ? get_theme_mod( 'bgtfw_body_link_color_hover' ) : 0;
 						$sidebar_ari_color   = ariColor::newColor( $sidebar_color_value );
 						$sidebar_lightness   = min( $sidebar_ari_color->lightness + $sidebar_color_hover, 100 );
 						$sidebar_lightness   = max( $sidebar_lightness, 0 );


### PR DESCRIPTION
Resolves #741

### Testing Instructions ###
1. Install Test zip.
[crio.zip](https://github.com/BoldGrid/boldgrid-theme-framework/files/9904208/crio.zip)

2. Open Customizer to a page with a sidebar
3. The link color of the widgets in the sidebar can be set in `Widgets > Primary Sidebar > Links Color`
4. The hover effects of the widget links, will match the hover effects of the body links, set in `Design > Site Content > Links > Hover Color Brightness & Hover Text Style`, however the lightening / darkening amount will be applied to the widget link color.
5. Ensure that the color of the links matches the color set for the Primary Sidebar
6. Ensure that the lightening / darkening of the links on hover matches the hover settings in the body links control.
7. Ensure that the underline of the links on hover matches the hover settings in the body links control.